### PR TITLE
use heroku/heroku-buildpack-apit

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/ddollar/heroku-buildpack-apt
+https://github.com/heroku/heroku-buildpack-apt
 https://github.com/heroku/heroku-buildpack-ruby


### PR DESCRIPTION
buildpack ddollar/heroku-buildpack-apt is deprecated. And heroku provided a fork of that.

So I changed a url of buildpack.